### PR TITLE
feat: Add option to override simulation name

### DIFF
--- a/src/main/java/io/gatling/shared/cli/GatlingCliOptions.java
+++ b/src/main/java/io/gatling/shared/cli/GatlingCliOptions.java
@@ -34,6 +34,12 @@ public final class GatlingCliOptions {
           "<directoryPath>");
   public static final CliOption Simulation =
       new CliOption("simulation", "s", "Runs <className> simulation", "<className>");
+  public static final CliOption SimulationName =
+      new CliOption(
+          "simulation-name",
+          "sn",
+          "Overrides simulation name with <simulationName>",
+          "<simulationName>");
   public static final CliOption RunDescription =
       new CliOption(
           "run-description",


### PR DESCRIPTION
Motivation:

Needed to allow Gatling JS runner to specify the correct simulation name.

Modifications:

Adds a CLI option '--simulation-name'.

Result:

Can be used to specify a simulation name different from the class name.