### PR TITLE
Revert "feat: Add option to override simulation name"

### DIFF
--- a/src/main/java/io/gatling/shared/cli/GatlingCliOptions.java
+++ b/src/main/java/io/gatling/shared/cli/GatlingCliOptions.java
@@ -34,12 +34,6 @@ public final class GatlingCliOptions {
           "<directoryPath>");
   public static final CliOption Simulation =
       new CliOption("simulation", "s", "Runs <className> simulation", "<className>");
-  public static final CliOption SimulationName =
-      new CliOption(
-          "simulation-name",
-          "sn",
-          "Overrides simulation name with <simulationName>",
-          "<simulationName>");
   public static final CliOption RunDescription =
       new CliOption(
           "run-description",


### PR DESCRIPTION
This reverts commit 75b6fd2738174e5dbaa5f0ad72bbb235c534658f.

Not actually needed, we can use the system property expected by `io.gatling.js.JsSimulation`.